### PR TITLE
Fix wrong dependency to septo3d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# {# pkglts, github
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -11,6 +10,7 @@ __pycache__/
 *.egg-info
 .eggs
 .Python
+*.pth
 dist/
 build/
 env/
@@ -28,8 +28,29 @@ lib64/
 # editors
 .idea/
 
+# Vim files
+*.swp
+*.*~
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+.settings
+
+
 # C extensions
 *.so
+*.dll
+*.dylib
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+
+# Compiled Object files
+*.os
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -40,6 +61,8 @@ lib64/
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+.amlog
+.sconsign.dblite
 
 # Translations
 *.mo
@@ -54,6 +77,9 @@ target/
 # jupyter notebooks
 .ipynb_checkpoints/
 
+# svn
+.svn
+.cache/
 
 # coverage
 .coverage
@@ -61,8 +87,7 @@ target/
 # sphinx autogen file
 doc/_dvlpt/
 
-
-# #}
-
 # user custom filters
 
+# Mac
+.DS_Store

--- a/src/alinea/astk/Weather.py
+++ b/src/alinea/astk/Weather.py
@@ -255,10 +255,13 @@ def date_range_node(start, end, periods, freq, tz, normalize,
 def sample_weather(periods=24):
     """ provides a sample weather instance for testing other modules
     """
-    from openalea.deploy.shared_data import shared_data
-    import alinea.septo3d
+    #from openalea.deploy.shared_data import shared_data
+    #import alinea.septo3d
+    import astk_data
+    from path import Path
 
-    meteo_path = shared_data(alinea.septo3d, 'meteo00-01.txt')
+    meteo_path = Path(astk_data.__path__[0])/'meteo00-01.txt'
+    #meteo_path = shared_data(alinea.septo3d, 'meteo00-01.txt')
     t_deb = "2000-10-01 01:00:00"
     seq = pandas.date_range(start="2000-10-02", periods=periods, freq='H')
     weather = Weather(data_file=meteo_path)

--- a/src/alinea/astk/meteorology/sun_position.py
+++ b/src/alinea/astk/meteorology/sun_position.py
@@ -19,7 +19,10 @@ import pandas
 
 try:
     from pvlib.solarposition import get_solarposition
-    from pvlib.irradiance import get_extra_radiation
+    try:
+        from pvlib.irradiance import get_extra_radiation
+    except ImportError:
+        from pvlib.irradiance import extraradiation as get_extra_radiation
 except ImportError as e:
     raise ImportError(
         '{0}\npvlib not found on your system, you may use sun_position_astk '


### PR DESCRIPTION
Conda-forge version of pvlib for Python 2.7 do not implement get_extra_irradiance.

Fix  error in sample_weather function that import septo3d. 
Close #13