### PR TITLE
Fix azimuth redefinition in sky_source

### DIFF
--- a/test/test_sky_sources.py
+++ b/test/test_sky_sources.py
@@ -5,6 +5,7 @@ from openalea.astk.sky_sources import (
     regular_sky,
     sky_turtle,
     sky_sources,
+    polar_angle,
     source_ni)
 
 
@@ -44,8 +45,9 @@ def test_sky_sources():
     assert len(sky) == 46
     el, az, irr = map(numpy.array, zip(*sky))
     lum = source_ni(sky)
-    north = numpy.where(az <= 180)
-    south = numpy.where(az > 180)
+    pol = polar_angle(az, 90)
+    north = numpy.where(pol <= 180)
+    south = numpy.where(pol > 180)
     numpy.testing.assert_almost_equal(lum[north].sum(),
                                       lum[south].sum(),
                                       decimal=1)
@@ -55,8 +57,9 @@ def test_sky_sources():
     assert len(sky) == 46
     el, az, irr = map(numpy.array, zip(*sky))
     lum = source_ni(sky)
-    north = numpy.where(az <= 180)
-    south = numpy.where(az > 180)
+    pol = polar_angle(az, 90)
+    north = numpy.where(pol <= 180)
+    south = numpy.where(pol > 180)
     numpy.testing.assert_almost_equal(lum[north].sum(),
                                       lum[south].sum(),
                                       decimal=1)
@@ -66,28 +69,32 @@ def test_sky_sources():
     assert len(sky) == 46
     el, az, irr = map(numpy.array, zip(*sky))
     lum = source_ni(sky)
-    north = numpy.where(az <= 180)
-    south = numpy.where(az > 180)
+    pol = polar_angle(az, 90)
+    north = numpy.where(pol <= 180)
+    south = numpy.where(pol > 180)
     numpy.testing.assert_almost_equal(lum[south].sum() - lum[north].sum(), 0.76, decimal=2)
 
-    sun, sky = sky_sources('sun_soc', sky_irradiance=sky_irr, sun_in_sky=True, north=-90)
+    sun, sky = sky_sources('sun_soc', sky_irradiance=sky_irr, sun_in_sky=True)
     el, az, irr = map(numpy.array, zip(*sky))
     lum = source_ni(sky)
-    north = numpy.where(az > 180)
-    south = numpy.where(az <= 180)
+    # North is along Y-
+    pol = polar_angle(az, -90)
+    north = numpy.where(pol > 180)
+    south = numpy.where(pol <= 180)
     numpy.testing.assert_almost_equal(lum[south].sum() - lum[north].sum(), 0.76, decimal=2)
 
     sun, sky = sky_sources('blended', sky_irradiance=sky_irr)
     el, az, irr = map(numpy.array, zip(*sky))
     lum = source_ni(sky)
-    north = numpy.where((az <= 180) & (el > 45))
-    south = numpy.where((az > 180) & (el > 45))
+    pol = polar_angle(az, 90)
+    north = numpy.where((pol <= 180) & (el > 45))
+    south = numpy.where((pol > 180) & (el > 45))
     delta_cs = lum[south].sum() - lum[north].sum()
     sun, sky = sky_sources('blended', sky_irradiance=sky_irradiance(attenuation=0.2))
     el, az, irr = map(numpy.array, zip(*sky))
     lum = source_ni(sky)
-    north = numpy.where((az <= 180) & (el > 45))
-    south = numpy.where((az > 180) & (el > 45))
+    north = numpy.where((pol <= 180) & (el > 45))
+    south = numpy.where((pol > 180) & (el > 45))
     delta_soc = lum[south].sum() - lum[north].sum()
     numpy.testing.assert_almost_equal(delta_cs / delta_soc, 14.6, decimal=1)
 


### PR DESCRIPTION
Fix the user-confusing change of azimuth definition in sky sources (input=azimuth, output = polar angle, but still called azimuth)
Allows saving time in repeated calls to sky_map 